### PR TITLE
Update install_nquake.sh

### DIFF
--- a/src/install_nquake.sh
+++ b/src/install_nquake.sh
@@ -296,8 +296,3 @@ echo
 echo "=== Installation Complete ==="
 echo "nQuake was successfully installed. Happy gibbing!"
 echo
-echo "Please note:"
-echo "For optimal mouse support, run /evdevlist and set your /in_evdevice to the right device number (ingame). Ensure that /in_mouse is 3 and then do /in_restart (also ingame). Note that you need to \"sudo chmod 644 /dev/input/event??\" for this to work."
-echo
-echo "The default resolution is set for a widescreen display. If you have a non-widescreen display, a black bar will appear at the top of your screen. To fix this, go to Options -> System and change your resolution accordingly."
-echo


### PR DESCRIPTION
Removed the echoed text on the end of the installation. It is no longer valid on ezQuake 3.0
