### PR TITLE
fix gpl_maps.pk3 path for cleanup stage

### DIFF
--- a/src/install_nquake.sh
+++ b/src/install_nquake.sh
@@ -237,7 +237,7 @@ if [ "$pak" != "" ]
 then
 	echo -n "* Copying pak1.pak..."
 	cp $pak $directory/id1/pak1.pak 2> /dev/null
-	rm -rf $directory/id1/gpl-maps.pk3 $directory/id1/readme.txt
+	rm -rf $directory/id1/gpl_maps.pk3 $directory/id1/readme.txt
 	echo "done"
 fi
 echo


### PR DESCRIPTION
When installing with an existing pak1, gpl-maps.pk3 has to be removed, but the actual file to be removed is called gpl**_**maps.pk3, not gpl**-**maps.pk3 - therefore the user has both pak0|1.pak and the unneeded gpl maps on top.
This makes it so the pk3 is actually removed.